### PR TITLE
fix/footer-fix-for-github-404

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,6 +1,7 @@
 <template>
 	<footer>
-		<h3> ☕ & code by 😎 <router-link :to="https://github.com/geekmaros"> geekmaros </router-link> </h3>
+		<h3> ☕ & code by 😎       <a href="https://github.com/geekmaros">geekmaros</a>
+ </h3>
 			
 	</footer>
 </template>
@@ -12,7 +13,6 @@ export default {
 
   data() {
     return {
-      git: 'https://github.com/geekmaros'
     };
   },
   props:{


### PR DESCRIPTION
Attached is the error message

![Page Not Found](https://user-images.githubusercontent.com/10975011/60834903-afaec900-a1b9-11e9-8908-36cd062d7967.png)

For external links, just use <a href="..."> to point directly to whatever you're linking to. Vue-router is only needed for internal links